### PR TITLE
Add status page and update warning.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,4 +59,4 @@ BuildVignettes: true
 VignetteBuilder: knitr
 BugReports: https://github.com/DOI-USGS/dataRetrieval/issues
 URL: https://code.usgs.gov/water/dataRetrieval
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dataRetrieval
 Type: Package
 Title: Retrieval Functions for USGS and EPA Hydrology and Water Quality Data
-Version: 2.7.14
+Version: 2.7.14.1
 Authors@R: c(
     person("Laura", "DeCicco", role = c("aut","cre"),
             email = "ldecicco@usgs.gov",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+dataRetrieval 2.7.15
+===================
+* Update warning about upcoming changes to USGS water quality data.
+
 dataRetrieval 2.7.14
 ===================
 * Package documentation updated due to roxygen changes

--- a/R/dataRetrievals-package.R
+++ b/R/dataRetrievals-package.R
@@ -27,7 +27,8 @@ Extended Documentation: https://doi-usgs.github.io/dataRetrieval")
 #' @aliases dataRetrieval-package
 #' @docType package
 #' @author Laura De Cicco \email{ldecicco@@usgs.gov}
-NULL
+#' @keywords internal 
+"_PACKAGE"
 
 #' List of USGS parameter codes
 #'

--- a/R/readNWISqw.R
+++ b/R/readNWISqw.R
@@ -106,10 +106,13 @@ readNWISqw <- function(siteNumbers,
                        tz = "UTC") {
   .Deprecated(
     new = "readWQPqw", package = "dataRetrieval",
-    msg = "NWIS qw web services are being retired.
-Please see vignette('qwdata_changes', package = 'dataRetrieval')
-for more information.
-https://cran.r-project.org/web/packages/dataRetrieval/vignettes/qwdata_changes.html"
+    msg = "WARNING: Beginning in February 2024 the NWIS qw data endpoint will not deliver new data or updates to existing data. 
+Eventually the endpoint will be retired. For updated information visit:
+https://waterdata.usgs.gov/nwis/qwdata
+For additional details, see vignettes:
+https://doi-usgs.github.io/dataRetrieval/articles/Status.html
+https://doi-usgs.github.io/dataRetrieval/articles/qwdata_changes.html
+If you have additional questions about the qw data service, email CompTools@usgs.gov."
   )
 
   pgrp <- c(

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -22,13 +22,19 @@ navbar:
     href: articles/dataRetrieval.html
   - text: Function Help
     href: reference/index.html
-  - text: Large Data Pull Examples
+  - text: Large Data Pulls
     menu:
     - text: Scripting Approach
       href: articles/wqp_large_pull_script.html
     - text: Pipeline Approach
       href: articles/wqp_large_pull_targets.html
-  - text: Articles
+  - text: Water Quality Changes
+    menu:
+    - text: Changes to QW
+      href: articles/qwdata_changes.html
+    - text: USGS QW Status
+      href: articles/Status.html
+  - text: Additional Articles
     menu:
     - text: Tutorial
       href: articles/tutorial.html

--- a/man/dataRetrieval.Rd
+++ b/man/dataRetrieval.Rd
@@ -23,6 +23,15 @@ Retrieval functions for USGS and EPA hydrologic and water quality data.
 
 Please see \url{https://pubs.usgs.gov/publication/tm4A10} for more information.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://code.usgs.gov/water/dataRetrieval}
+  \item Report bugs at \url{https://github.com/DOI-USGS/dataRetrieval/issues}
+}
+
+}
 \author{
 Laura De Cicco \email{ldecicco@usgs.gov}
 }
+\keyword{internal}

--- a/vignettes/Status.Rmd
+++ b/vignettes/Status.Rmd
@@ -42,16 +42,16 @@ For additional details, see vignette:
 
 If you have additional questions about the qw data service, email CompTools@usgs.gov.
 
-It is planned that when NWIS qw service will be shut down - the `readNWISqw` will be removed from dataRetrieval.
+When NWIS qw service is shut down - the `readNWISqw` will be removed from dataRetrieval.
 
 
 See [Changes to NWIS QW services](articles/qwdata_changes.html) for information on how to convert your workflows from `readNWISqw` to `readWQPqw`.
 
 ## WQP: USGS Data
 
-Limited availability of new USGS data: starting approximately February 12, 2024, there will be a period when new USGS data will not be accessible on the Water Quality Portal. Data will still be collected but will not be publicly available. This limited availability is expected to last a few weeks.
+Limited availability of **new** USGS data: starting approximately February 12, 2024, there will be a period when new USGS data will not be accessible on the Water Quality Portal. Data will still be collected but will not be publicly available. This limited availability is expected to last a few weeks.
 
-Recent USGS data will be accessible again upon release of the new Data Profiles, which will be in the WQX 3.0 format. These profiles should be available in March, 2024.
+Recent USGS data will be accessible again upon release of the new Data Profiles, which will be in the WQX 3.0 format. These profiles should be available starting in March, 2024.
 
-These profiles are not yet available to test. When the are, we will update this page with recommendations.
+These profiles are not yet available to test. When they are, we will update this page with recommendations.
  

--- a/vignettes/Status.Rmd
+++ b/vignettes/Status.Rmd
@@ -1,0 +1,57 @@
+---
+title: "dataRetrieval Status"
+date: Sys.Date()
+output: 
+  rmarkdown::html_vignette:
+    toc: true
+    fig_caption: yes
+    fig_height: 7
+    fig_width: 7
+vignette: >
+  %\VignetteIndexEntry{dataRetrieval Status}
+  \usepackage[utf8]{inputenc}
+  %\VignetteEngine{knitr::rmarkdown}
+editor_options: 
+  chunk_output_type: console
+---
+
+This page will be updated frequently with information about the status of dataRetrieval services.
+
+# Current Status
+
+## readNWISqw
+
+Functions normally, includes new data. This function is deprecated, so consider switching to `readWQPqw`
+
+## WQP
+
+Functioning normally, includes new USGS data. See below for upcoming information.
+
+# Overview of changes
+
+## NWIS qw services
+
+Discrete water samples data are undergoing modernization, and NWIS services will no longer being updated with the latest data starting in February 2024, with a full decommission expected 6 months later. Learn more about the upcoming change and where to find the new samples data in our [blog](https://waterdata.usgs.gov/blog/changes-to-sample-data/).
+
+
+For updated information visit:
+[https://waterdata.usgs.gov/nwis/qwdata](https://waterdata.usgs.gov/nwis/qwdata)
+
+For additional details, see vignette:
+[https://doi-usgs.github.io/dataRetrieval/articles/qwdata_changes.html](https://doi-usgs.github.io/dataRetrieval/articles/qwdata_changes.html)
+
+If you have additional questions about the qw data service, email CompTools@usgs.gov.
+
+It is planned that when NWIS qw service will be shut down - the `readNWISqw` will be removed from dataRetrieval.
+
+
+See [Changes to NWIS QW services](articles/qwdata_changes.html) for information on how to convert your workflows from `readNWISqw` to `readWQPqw`.
+
+## WQP: USGS Data
+
+Limited availability of new USGS data: starting approximately February 12, 2024, there will be a period when new USGS data will not be accessible on the Water Quality Portal. Data will still be collected but will not be publicly available. This limited availability is expected to last a few weeks.
+
+Recent USGS data will be accessible again upon release of the new Data Profiles, which will be in the WQX 3.0 format. These profiles should be available in March, 2024.
+
+These profiles are not yet available to test. When the are, we will update this page with recommendations.
+ 

--- a/vignettes/Status.Rmd
+++ b/vignettes/Status.Rmd
@@ -31,7 +31,7 @@ Functioning normally, includes new USGS data. See below for upcoming information
 
 ## NWIS qw services
 
-Discrete water samples data are undergoing modernization, and NWIS services will no longer being updated with the latest data starting in February 2024, with a full decommission expected 6 months later. Learn more about the upcoming change and where to find the new samples data in our [blog](https://waterdata.usgs.gov/blog/changes-to-sample-data/).
+Discrete water samples data are undergoing modernization, and NWIS services will no longer be updated with the latest data starting in February 2024, with a full decommission expected 6 months later. Learn more about the upcoming change and where to find the new samples data in our [blog](https://waterdata.usgs.gov/blog/changes-to-sample-data/).
 
 
 For updated information visit:


### PR DESCRIPTION


Here's how it looks:
```r
y <- readNWISqw("391259097001800", parameterCd = "00605")
Warning message:                                                                                     
WARNING: Beginning in February 2024 the NWIS qw data endpoint will not deliver new data or updates to existing data. 
Eventually the endpoint will be retired. For updated information visit:
https://waterdata.usgs.gov/nwis/qwdata
For additional details, see vignettes:
https://doi-usgs.github.io/dataRetrieval/articles/Status.html
https://doi-usgs.github.io/dataRetrieval/articles/qwdata_changes.html
If you have additional questions about the qw data service, email CompTools@usgs.gov
```

We can merge this PR and make sure the documentation deploys as expected. Here's how the banner looks on my screen locally:

![image](https://github.com/DOI-USGS/dataRetrieval/assets/1105215/38701b77-34bc-4c68-a13d-aa4ff8935d2e)



