### PR TITLE
Allow `pcode_to_name` to modify duplicate pcodes without producing a warning

### DIFF
--- a/R/pcode_to_name.R
+++ b/R/pcode_to_name.R
@@ -37,7 +37,7 @@ pcode_to_name <- function(parameterCd = "all"){
   attr(retval, "url") <- url_all
   
   if(any(parameterCd != "all")){
-    if (nrow(retval) != length(parameterCd)) {
+    if (nrow(retval) != length(unique(parameterCd))) {
       badPcode <- parameterCd[!(parameterCd %in% retval$parm_cd)]
       warning(
         "The following pCodes seem mistyped, and no information was returned: ",


### PR DESCRIPTION
## Overview
This PR fixes the false warnings described in #702

## Major changes
No major edits! I added one quick fix to the `pcode_to_name` function

## Verification 
After using devtools to re-install the package you should see the following:

Script:
```
library(dataRetrieval)

pcodes <- c("00060", "00065", "00065", "1234")

# works as expected
pcode_to_name(pcodes[1:2])$characteristicname

# works as expected - with the fix
pcode_to_name(pcodes[1:3])$characteristicname

# real errors
pcode_to_name(pcodes)$characteristicname
pcode_to_name(pcodes[3:4])$characteristicname
```

Results:
```
> # works as expected
> pcode_to_name(pcodes[1:2])$characteristicname
[1] "Stream flow"  "Height, gage"
> # works as expected - with the fix
> pcode_to_name(pcodes[1:3])$characteristicname
[1] "Stream flow"  "Height, gage" "Height, gage"
> # real errors
> pcode_to_name(pcodes)$characteristicname
[1] "Stream flow"  "Height, gage" "Height, gage" NA            
Warning message:
In pcode_to_name(pcodes) :
  The following pCodes seem mistyped, and no information was returned: 1234
> pcode_to_name(pcodes[3:4])$characteristicname
[1] "Height, gage" NA            
Warning message:
In pcode_to_name(pcodes[3:4]) :
  The following pCodes seem mistyped, and no information was returned: 1234
```

closes #702