### PR TITLE
stateCd "whatNWISsites" function fix

### DIFF
--- a/R/readNWISdata.R
+++ b/R/readNWISdata.R
@@ -506,7 +506,8 @@ readNWISdots <- function(...) {
     }
   }
   
-  if (service %in% c("peak", "gwlevels") && "state_cd" %in% names(values)) {
+  if (service %in% c("peak", "gwlevels") && "stateCd" %in% names(values)) {
+    names(values)[names(values) == "stateCd"] <- "state_cd"
     values["list_of_search_criteria"] <- "state_cd"
   }
   

--- a/R/whatNWISdata.R
+++ b/R/whatNWISdata.R
@@ -74,7 +74,7 @@
 #' uvDataMulti <- whatNWISdata(siteNumber = c("05114000", "09423350"),
 #'                             service = c("uv", "dv"))
 #' flowAndTemp <- whatNWISdata(
-#'   stateCd = "WI", service = "uv",
+#'   stateCd = "WI", service = "dv",
 #'   parameterCd = c("00060", "00010"),
 #'   statCd = "00003"
 #' )
@@ -82,6 +82,9 @@
 #'                       parameterCd = "00060",
 #'                       siteType = "ST", 
 #'                       service = "site")
+#'                       
+#' sites <- whatNWISdata(stateCd = "WI",
+#'                       service = "gwlevels")
 #' }
 whatNWISdata <- function(..., convertType = TRUE) {
   matchReturn <- convertLists(...)
@@ -110,6 +113,8 @@ whatNWISdata <- function(..., convertType = TRUE) {
     service[service == "peak"] <- "pk"
   } else if (any(service == "measurements")) {
     service[service == "measurements"] <- "sv"
+  } else if(any(service == "gwlevels")) {
+    service[service == "gwlevels"] <- "gw"
   }
   
   if ("statCd" %in% names(matchReturn)) {
@@ -163,3 +168,4 @@ whatNWISdata <- function(..., convertType = TRUE) {
   }
   return(SiteFile)
 }
+

--- a/R/whatNWISsites.R
+++ b/R/whatNWISsites.R
@@ -34,11 +34,32 @@
 #' oneSite <- whatNWISsites(sites = "05114000")
 #' }
 whatNWISsites <- function(...) {
+
+  matchReturn <- convertLists(...)
   valuesList <- readNWISdots(...)
 
   values <- sapply(valuesList$values, function(x) utils::URLencode(x))
   values["format"] <- "mapper"
+  
+  #################
+  # temporary gwlevels fixes
+  values <- values[!names(values) %in% c("date_format",
+                                        "TZoutput",
+                                        "rdb_inventory_output",
+                                        "list_of_search_criteria")]
+  
 
+  names(values)[names(values) == "state_cd"] <- "stateCd"
+  ##################
+  
+  if("service" %in% names(matchReturn)){
+    values["hasDataTypeCd"] <- switch(valuesList$service,
+                                      "gwlevels" = "gw",
+                                      "iv" = "iv",
+                                      "dv" = "dv",
+                                      "peak" = "pk")
+  }
+  
   urlCall <- drURL("site", Access = pkg.env$access, arg.list = values)
 
   rawData <- getWebServiceData(urlCall, encoding = "gzip")

--- a/man/whatNWISdata.Rd
+++ b/man/whatNWISdata.Rd
@@ -84,7 +84,7 @@ uvData <- whatNWISdata(siteNumber = "05114000",
 uvDataMulti <- whatNWISdata(siteNumber = c("05114000", "09423350"),
                             service = c("uv", "dv"))
 flowAndTemp <- whatNWISdata(
-  stateCd = "WI", service = "uv",
+  stateCd = "WI", service = "dv",
   parameterCd = c("00060", "00010"),
   statCd = "00003"
 )
@@ -92,6 +92,9 @@ sites <- whatNWISdata(stateCd = "WI",
                       parameterCd = "00060",
                       siteType = "ST", 
                       service = "site")
+                      
+sites <- whatNWISdata(stateCd = "WI",
+                      service = "gwlevels")
 }
 \dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/tests_general.R
+++ b/tests/testthat/tests_general.R
@@ -59,6 +59,24 @@ test_that("General NWIS retrievals working", {
   )
   expect_is(siteInfo$station_nm, "character")
 
+  gw_data <- readNWISdata(
+    stateCd = "AL",
+    service = "gwlevels",
+    startDate = "2024-05-01",
+    endDate = "2024-05-30") 
+  
+  expect_true(nrow(gw_data) > 0)
+  expect_equal(attr(gw_data, "url"),
+               "https://nwis.waterdata.usgs.gov/nwis/gwlevels?state_cd=AL&begin_date=2024-05-01&end_date=2024-05-30&date_format=YYYY-MM-DD&rdb_inventory_output=file&TZoutput=0&range_selection=date_range&list_of_search_criteria=state_cd&format=rdb")
+  
+  gw_data2 <- readNWISdata(
+    state_cd = "AL",
+    service = "gwlevels",
+    startDate = "2024-05-01",
+    endDate = "2024-05-30") 
+  
+  expect_equal(nrow(gw_data), nrow(gw_data2))
+  
   # nolint start: line_length_linter
   url <- "https://waterservices.usgs.gov/nwis/dv/?site=09037500&format=rdb&ParameterCd=00060&StatCd=00003&startDT=1985-10-02&endDT=2012-09-06"
   dv <- importRDB1(url, asDateTime = FALSE)
@@ -346,6 +364,11 @@ test_that("whatNWISsites working", {
   bboxSites <- whatNWISsites(bbox = c(-92.5, 45.4, -87, 47), parameterCd = "00060")
   expect_true(nrow(bboxSites) > 0)
   expect_true(is.numeric(bboxSites$dec_lat_va))
+  
+  #gwlevels:
+  info <- whatNWISsites(stateCd = "NY", service="gwlevels") 
+  expect_true(nrow(info) > 0)
+  expect_equal(attr(info, "url"), "https://waterservices.usgs.gov/nwis/site/?stateCd=NY&format=mapper&hasDataTypeCd=gw")
 })
 
 context("readWQPdots")


### PR DESCRIPTION
Two things here:
1. When we changed the stateCd stuff for readNWISdata, it also changed it for whatNWISsites. Since in whatNWISsites we're still hitting the "waterservices" endpoint (not "waterdata"), we don't want that to happen.
2. A user wanted to do:
```r
whatNWISsites(stateCd = "NY", service="gwlevels") 
```
That's cool...but it wasn't something we were doing. I added a line that took the service argument and converted it to the appropriate "hasDataTypeCd" argument