### PR TITLE
update nldi URL for new prod API

### DIFF
--- a/R/AAA.R
+++ b/R/AAA.R
@@ -2,7 +2,7 @@ pkg.env <- new.env()
 
 .onLoad <- function(libname, pkgname) {
   suppressMessages(setAccess("public"))
-  pkg.env$nldi_base <- "https://labs.waterdata.usgs.gov/api/nldi/linked-data/"
+  pkg.env$nldi_base <- "https://api.water.usgs.gov/nldi/linked-data/"
   pkg.env$local_sf <- requireNamespace("sf", quietly = TRUE)
 }
 

--- a/R/findNLDI.R
+++ b/R/findNLDI.R
@@ -75,7 +75,7 @@ get_nldi_sources <- function(url = pkg.env$nldi_base) {
 #' @return a data.frame
 #' @examplesIf is_dataRetrieval_user()
 #' \donttest{
-#' base <- "https://labs.waterdata.usgs.gov/api/nldi/linked-data/"
+#' base <- ""https://api.water.usgs.gov/nldi/linked-data/"
 #' get_nldi(paste0(base, "comid/101"), type = "feature", use_sf = FALSE)
 #' get_nldi(paste0(base, "comid/101"), type = "feature", use_sf = TRUE)
 #' get_nldi(url = paste0(base, "nwissite/USGS-11120000"), type = "feature", use_sf = TRUE)


### PR DESCRIPTION
The NLDI is moving to a new URL. Nothing is changing except this new URL which uses the api.data.gov service. 